### PR TITLE
fix: arreglar errores de cache despues de enviar un formulario

### DIFF
--- a/controllers/alumnos.controller.js
+++ b/controllers/alumnos.controller.js
@@ -291,9 +291,9 @@ exports.post_eliminar_pago_dip = async (request, response, next) => {
     }
 }
 
-exports.post_fetch_datos = async (request, response, next) => {
+exports.get_fetch_datos = async (request, response, next) => {
     try {
-        let matches = request.body.buscar.match(/(\d+)/);
+        let matches = request.params.matricula.match(/(\d+)/);
         const matricula = matches[0];
         const periodo = await Periodo.fetchActivo();
         const now = moment().tz('America/Mexico_City').startOf('day').subtract(1, 'days').format();
@@ -424,6 +424,23 @@ exports.post_fetch_datos = async (request, response, next) => {
                 csrfToken: request.csrfToken()
             });
         }
+    } catch (error) {
+        console.log(error);
+        response.status(500).render('500', {
+            username: request.session.username || '',
+            permisos: request.session.permisos || [],
+            rol: request.session.rol || "",
+            error_alumno: false
+        });
+    }
+};
+
+exports.post_fetch_datos = async (request, response, next) => {
+    try {
+        let matches = request.body.buscar.match(/(\d+)/);
+        const matricula = matches[0];
+
+        response.redirect(`/alumnos/datos_alumno/${matricula}`);
     } catch (error) {
         console.log(error);
         response.status(500).render('500', {

--- a/controllers/pagos.controller.js
+++ b/controllers/pagos.controller.js
@@ -10,10 +10,6 @@ const Colegiatura = require('../models/colegiatura.model');
 const Usuario = require('../models/usuario.model');
 const Reporte = require('../models/reporte.model');
 
-const {
-    post_fetch_datos
-} = require('./alumnos.controller');
-
 const csvParser = require('csv-parser');
 const fs = require('fs');
 const stream = require('stream');
@@ -628,11 +624,7 @@ exports.post_registrar_pago_manual_pago_extra = (request, response, next) => {
                     // Crear solicitud pagada de la nueva categoría de Pago Extra
                     await Liquida.save_pago_manual(matricula, pagoID, fecha, metodo, nota)
                         .then(async ([rows, fieldData]) => {
-                            // Definir la matrícula que use la función post_fetch_datos
-                            request.body.buscar = matricula;
-                
-                            // Llamar la función para hacer el render
-                            await post_fetch_datos(request, response, next);
+                            response.redirect(`/alumnos/datos_alumno/${matricula}`);
                         })
                         .catch((error) => {
                             console.error('Error while saving manual payment:', error);
@@ -657,11 +649,7 @@ exports.post_registrar_pago_manual_pago_extra = (request, response, next) => {
             if (pendientes.length == 0) {
                 Liquida.save_pago_manual(matricula, pago, fecha, metodo, nota)
                     .then(async ([rows, fieldData]) => {
-                        // Definir la matrícula que use la función post_fetch_datos
-                        request.body.buscar = matricula;
-
-                        // Llamar la función para hacer el render
-                        await post_fetch_datos(request, response, next);
+                        response.redirect(`/alumnos/datos_alumno/${matricula}`);
                     })
                     .catch((error) => {
                         response.status(500).render('500', {
@@ -685,11 +673,7 @@ exports.post_registrar_pago_manual_pago_extra = (request, response, next) => {
                             update = true;
                             Liquida.update_pago_manual(matricula, pago, fecha, metodo, nota, liquida)
                                 .then(async ([rows, fieldData]) => {
-                                    // Definir la matrícula que use la función post_fetch_datos
-                                    request.body.buscar = matricula;
-
-                                    // Llamar la función para hacer el render
-                                    await post_fetch_datos(request, response, next);
+                                    response.redirect(`/alumnos/datos_alumno/${matricula}`);
                                 })
                                 .catch((error) => {
                                     response.status(500).render('500', {
@@ -707,11 +691,7 @@ exports.post_registrar_pago_manual_pago_extra = (request, response, next) => {
                 if (update == false) {
                     Liquida.save_pago_manual(matricula, pago, fecha, metodo, nota)
                         .then(async ([rows, fieldData]) => {
-                            // Definir la matrícula que use la función post_fetch_datos
-                            request.body.buscar = matricula;
-
-                            // Llamar la función para hacer el render
-                            await post_fetch_datos(request, response, next);
+                            response.redirect(`/alumnos/datos_alumno/${matricula}`);
                         })
                         .catch((error) => {
                             response.status(500).render('500', {
@@ -749,11 +729,7 @@ exports.post_registrar_pago_manual_diplomado = (request, response, next) => {
 
     PagoDiplomado.save_pago_manual(matricula, IDDiplomado, fecha, monto, motivo, nota, metodo)
         .then(async ([rows, fieldData]) => {
-            // Definir la matrícula que use la función post_fetch_datos
-            request.body.buscar = matricula;
-
-            // Llamar la función para hacer el render
-            await post_fetch_datos(request, response, next);
+            response.redirect(`/alumnos/datos_alumno/${matricula}`);
         })
         .catch((error) => {
             response.status(500).render('500', {
@@ -846,11 +822,7 @@ exports.post_registrar_pago_manual_colegiatura = (request, response, next) => {
                 await Alumno.update_credito(matricula, monto_a_usar);
             }
 
-            // Definir la matrícula que use la función post_fetch_datos
-            request.body.buscar = matricula;
-
-            // Llamar la función para hacer el render
-            await post_fetch_datos(request, response, next);
+            response.redirect(`/alumnos/datos_alumno/${matricula}`);
         })
         .catch((error) => {
             response.status(500).render('500', {

--- a/routes/alumnos.routes.js
+++ b/routes/alumnos.routes.js
@@ -16,6 +16,7 @@ router.get('/alumnos_atrasados', isAuth, can_AlumnosAtrasados, alumnosController
 
 //Consultar Alumno
 router.get('/fetch_datos', isAuth, can_ConsultarAlumno, alumnosController.get_datos);
+router.get('/datos_alumno/:matricula', isAuth, can_ConsultarAlumno, alumnosController.get_fetch_datos);
 router.post('/datos_alumno', isAuth, can_ConsultarAlumno, alumnosController.post_fetch_datos);
 router.post('/datos_alumno/modify', isAuth, can_ConsultarAlumno, alumnosController.post_datos_modify);
 router.post('/datos_alumno/dar_baja_grupo', isAuth, can_ConsultarAlumno, alumnosController.post_dar_baja_grupo);


### PR DESCRIPTION
En este PR se arregla el error de cache dentro de consultar alumnos, y modificando la ruta ya es posible con la matricula del alumno entrar a los datos de ese alumno. 